### PR TITLE
refactor: decouple domain from Unity vector types

### DIFF
--- a/Assets/Scripts/Domain/Entities/Enemy.cs
+++ b/Assets/Scripts/Domain/Entities/Enemy.cs
@@ -1,5 +1,5 @@
 using System;
- using UnityEngine;
+using System.Numerics;
 using MyGame.Domain.Interfaces;
 
 namespace MyGame.Domain.Entities
@@ -44,7 +44,7 @@ namespace MyGame.Domain.Entities
         /// <inheritdoc />
         public void TakeDamage(float amount)
         {
-            Health = Mathf.Max(0f, Health - amount);
+            Health = MathF.Max(0f, Health - amount);
             if (Health <= 0f)
             {
                 OnDeath?.Invoke();

--- a/Assets/Scripts/Domain/Entities/Player.cs
+++ b/Assets/Scripts/Domain/Entities/Player.cs
@@ -1,5 +1,5 @@
 using System;
-using UnityEngine;
+using System.Numerics;
 using MyGame.Domain.Interfaces;
 
 namespace MyGame.Domain.Entities
@@ -44,7 +44,7 @@ namespace MyGame.Domain.Entities
         /// <inheritdoc />
         public void TakeDamage(float amount)
         {
-            Health = Mathf.Max(0f, Health - amount);
+            Health = MathF.Max(0f, Health - amount);
             if (Health <= 0f)
             {
                 OnDeath?.Invoke();

--- a/Assets/Scripts/Domain/Entities/Projectile.cs
+++ b/Assets/Scripts/Domain/Entities/Projectile.cs
@@ -1,5 +1,3 @@
-using UnityEngine;
-
 namespace MyGame.Domain.Entities
 {
     /// <summary>

--- a/Assets/Scripts/Domain/Interfaces/IMovable.cs
+++ b/Assets/Scripts/Domain/Interfaces/IMovable.cs
@@ -1,4 +1,4 @@
-using UnityEngine;
+using System.Numerics;
 
 namespace MyGame.Domain.Interfaces
 {

--- a/Assets/Scripts/Presentation/Controllers/EnemyController.cs
+++ b/Assets/Scripts/Presentation/Controllers/EnemyController.cs
@@ -54,6 +54,7 @@ namespace MyGame.Presentation.Controllers
         {
             if (_target == null) return;
             Vector2 direction = (_target.position - transform.position).normalized;
+            _enemyData.Move(new System.Numerics.Vector2(direction.x, direction.y));
             _rigidbody2D.velocity = direction * _enemyData.Speed;
         }
 

--- a/Assets/Scripts/Presentation/Controllers/PlayerController.cs
+++ b/Assets/Scripts/Presentation/Controllers/PlayerController.cs
@@ -46,6 +46,7 @@ namespace MyGame.Presentation.Controllers
         private void HandleMovement()
         {
             Vector2 movement = GameBootstrap.InputService.MovementVector;
+            _playerData.Move(new System.Numerics.Vector2(movement.x, movement.y));
             Vector2 velocity = movement.normalized * _playerData.Speed;
             _rigidbody2D.linearVelocity = velocity;
 


### PR DESCRIPTION
## Summary
- replace UnityEngine.Vector2 and Mathf with System.Numerics.Vector2 and MathF in domain entities and IMovable interface
- update PlayerController and EnemyController to convert Unity vectors to domain vectors
- remove unused Unity references from Projectile entity

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68952201b5a4832a83840fe9d8b8f8f6